### PR TITLE
Move PHPUnit to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,9 @@
     "name": "konsulting/project-root",
     "description": "A simple package to determine the working root directory for a composer dependency",
     "require": {
-        "php": ">=5.6",
+        "php": ">=5.6"
+    },
+    "require-dev": {
         "phpunit/phpunit": "^5.0 | ^6.0 | ^7.0"
     },
     "license": "MIT",


### PR DESCRIPTION
As of now, we are unable to use `orchestra/testbench-dusk` with PHPUnit 8 due to current requirement.